### PR TITLE
Potential fix for code scanning alert no. 22: Database query built from user-controlled sources

### DIFF
--- a/pages/api/Yugioh/card/[cardId]/price-history.js
+++ b/pages/api/Yugioh/card/[cardId]/price-history.js
@@ -1,7 +1,10 @@
 import { MongoClient } from "mongodb";
 
 export default async function handler( req, res ) {
-    const { cardId, set, rarity, edition } = req.query;
+    let { cardId, set, rarity, edition } = req.query;
+    if (typeof cardId !== "string") {
+        return res.status(400).json({ error: "Invalid cardId parameter" });
+    }
 
     if ( !cardId || !set || !rarity || !edition ) {
         return res.status( 400 ).json( { error: "Missing parameters: cardId, set, rarity, edition" } );
@@ -20,7 +23,7 @@ export default async function handler( req, res ) {
 
         // Fetch global price history from "priceHistory"
         const globalDoc = await db.collection( "priceHistory" ).findOne(
-            { cardId, setName: set, rarity, edition },
+            { cardId: { $eq: cardId }, setName: set, rarity, edition },
             { projection: { history: 1, _id: 0 } }
         );
 


### PR DESCRIPTION
Potential fix for [https://github.com/gottasellemall69/card-test/security/code-scanning/22](https://github.com/gottasellemall69/card-test/security/code-scanning/22)

To fix the problem, we need to ensure that the `cardId` parameter is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. Additionally, we should validate that `cardId` is a string before using it in the query.

1. Validate that `cardId` is a string.
2. Use the `$eq` operator in the MongoDB query to ensure that `cardId` is treated as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
