### PR TITLE
Potential fix for code scanning alert no. 21: Database query built from user-controlled sources

### DIFF
--- a/pages/api/Yugioh/card/[cardId]/price-history.js
+++ b/pages/api/Yugioh/card/[cardId]/price-history.js
@@ -14,13 +14,13 @@ export default async function handler( req, res ) {
 
         // Fetch user-specific price history from "myCollection"
         const userDoc = await db.collection( "myCollection" ).findOne(
-            { setName: set, rarity, printing: edition },
+            { setName: { $eq: set }, rarity: { $eq: rarity }, printing: { $eq: edition } },
             { projection: { priceHistory: 1, _id: 0 } }
         );
 
         // Fetch global price history from "priceHistory"
         const globalDoc = await db.collection( "priceHistory" ).findOne(
-            { cardId, setName: set, rarity, edition },
+            { cardId: { $eq: cardId }, setName: { $eq: set }, rarity: { $eq: rarity }, edition: { $eq: edition } },
             { projection: { history: 1, _id: 0 } }
         );
 


### PR DESCRIPTION
Potential fix for [https://github.com/gottasellemall69/card-test/security/code-scanning/21](https://github.com/gottasellemall69/card-test/security/code-scanning/21)

To fix the problem, we need to ensure that the user-provided input is sanitized before being used in the MongoDB query. We can use the `$eq` operator to ensure that the input is treated as a literal value. This will prevent any potential NoSQL injection attacks.

- Modify the MongoDB query to use the `$eq` operator for the `set`, `rarity`, and `edition` fields.
- Ensure that all user-provided inputs are treated as literal values in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
